### PR TITLE
Specify byte order in to_bytes operations

### DIFF
--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -180,7 +180,7 @@ def get_setting(
     # u8 setting
     # 0x01 read
     # optional extra payload
-    command = b"\x1b\x69\x55" + setting.to_bytes(1) + b"\x01"
+    command = b"\x1b\x69\x55" + setting.to_bytes(1,'big') + b"\x01"
     if payload is not None:
         command += payload
     printer.write(command)
@@ -208,7 +208,7 @@ def write_setting(
     # u8 setting
     # 0x0 write
     # payload (size dependent on setting and machine series)
-    command = b"\x1b\x69\x55" + setting.to_bytes(1) + b"\x00"
+    command = b"\x1b\x69\x55" + setting.to_bytes(1, 'big') + b"\x00"
     command += payload
     printer.write(command)
     # retrieve status to make sure no errors occured
@@ -249,7 +249,7 @@ def configure(
 
     if action == 'set':
         if key == 'auto-power-on':
-            payload = value.to_bytes(1)
+            payload = value.to_bytes(1, 'big')
             write_setting(printer, 0x70, payload)
             get_status(printer, 0x0)
         elif key == 'power-off-delay':
@@ -257,7 +257,7 @@ def configure(
             # 0x30 series needs an extra byte here
             if series_code == 0x30:
                 payload += b"\x00"
-            payload += value.to_bytes(1)
+            payload += value.to_bytes(1, 'big')
             write_setting(printer, 0x41, payload)
             get_status(printer, 0x0)
         else:


### PR DESCRIPTION
When using `configure` operations like:

```
brother_ql -b pyusb -m QL-700 -p usb://04f9:2042 configure get auto-power-on
```

I would get an error

```
Traceback (most recent call last):
  File "/home/pplu/.local/bin/brother_ql", line 8, in <module>
    sys.exit(cli())
  File "/home/pplu/.local/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/pplu/.local/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/pplu/.local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/pplu/.local/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/pplu/.local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/pplu/.local/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/pplu/.local/lib/python3.10/site-packages/brother_ql/cli.py", line 234, in configure_cmd
    configure(
  File "/home/pplu/.local/lib/python3.10/site-packages/brother_ql/backends/helpers.py", line 252, in configure
    payload = value.to_bytes(1)
TypeError: to_bytes() missing required argument 'byteorder' (pos 2)
```

It seems like the byteorder parameter in to_bytes is now mandatory.

After applying this patch `set` and `get` operations are now working correctly.